### PR TITLE
use preact-iso for routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "preact": "^10.24.3",
-    "react-router-dom": "^6.27.0",
+    "preact-iso": "^2.8.1",
     "styled-components": "^6.1.13",
     "typescript": "^4.4.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,9 @@ importers:
       preact:
         specifier: ^10.24.3
         version: 10.24.3
-      react-router-dom:
-        specifier: ^6.27.0
-        version: 6.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      preact-iso:
+        specifier: ^2.8.1
+        version: 2.8.1(preact-render-to-string@6.5.11(preact@10.24.3))(preact@10.24.3)
       styled-components:
         specifier: ^6.1.13
         version: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1006,10 +1006,6 @@ packages:
 
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
-
-  '@remix-run/router@1.20.0':
-    resolution: {integrity: sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==}
-    engines: {node: '>=14.0.0'}
 
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
@@ -2508,6 +2504,17 @@ packages:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  preact-iso@2.8.1:
+    resolution: {integrity: sha512-RL0yDdJcSiB4Wnk4fBqq0OE9QCfTEW7B2ULf8GHPx72AtFE+j1NvabjBF6y3rBgrNWSuuPuuiN4L4KxYteQD2Q==}
+    peerDependencies:
+      preact: '>=10'
+      preact-render-to-string: '>=6.4.0'
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
   preact@10.24.3:
     resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
@@ -2558,19 +2565,6 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
-
-  react-router-dom@6.27.0:
-    resolution: {integrity: sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
-  react-router@6.27.0:
-    resolution: {integrity: sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -4171,8 +4165,6 @@ snapshots:
       fastq: 1.17.1
 
   '@polka/url@1.0.0-next.28': {}
-
-  '@remix-run/router@1.20.0': {}
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
@@ -5811,6 +5803,15 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  preact-iso@2.8.1(preact-render-to-string@6.5.11(preact@10.24.3))(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
   preact@10.24.3: {}
 
   pretty-error@4.0.0:
@@ -5855,18 +5856,6 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
-
-  react-router-dom@6.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@remix-run/router': 1.20.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.27.0(react@18.3.1)
-
-  react-router@6.27.0(react@18.3.1):
-    dependencies:
-      '@remix-run/router': 1.20.0
-      react: 18.3.1
 
   react@18.3.1:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,5 @@
-import React, { useCallback, useState } from 'react';
-import {
-  createBrowserRouter,
-  RouterProvider,
-} from 'react-router-dom';
+import { useCallback, useState } from 'react';
+import { LocationProvider, ErrorBoundary, Router, Route } from 'preact-iso';
 import routes from './routes';
 import Nav from './components/Nav';
 import { AppContext } from './utils/context';
@@ -10,8 +7,6 @@ import { getContextDataFromLocalstorage, storeContextDataToLocalstorage } from '
 import { IContextState } from './app';
 import { DefaultContextData } from './constants/app.constants';
 import styled from 'styled-components';
-
-const router = createBrowserRouter(routes);
 
 const AppContainer = styled.div`
   min-height: 100vh;
@@ -41,9 +36,13 @@ function App() {
     <AppContext.Provider value={{contextState, updateContext}}>
       <AppContainer>
         <Nav />
-        <React.Suspense fallback={null}>
-          <RouterProvider router={router} />
-        </React.Suspense>
+        <LocationProvider>
+          <Router>
+            {routes.map(({ path, Component }) => (
+              <Route path={path} component={Component} key={path} />
+            ))}
+          </Router>
+        </LocationProvider>
       </AppContainer>
     </AppContext.Provider>
   );

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -12,6 +12,11 @@ export interface IAppContext {
     updateContext?: (updatedData: Partial<IContextState>) => void;
 }
 
+export interface IRouteObject {
+    path: string;
+    Component: React.FunctionComponent;
+}
+
 
 declare global {
     interface Window {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { RouteObject } from 'react-router-dom';
+import { lazy } from 'preact-iso';
+import { IRouteObject } from './app';
 
-const Racer = React.lazy(() => import('./components/Racer'));
+const Racer = lazy(() => import('./components/Racer'));
 
-const routes: RouteObject[] = [
+const routes: IRouteObject[] = [
     {
         path: '/',
-        element: <Racer />,
+        Component: Racer,
     }
 ];
 


### PR DESCRIPTION
Migrate to `preact-iso` for routing, shaving off approx 20KB (gzipped) bundle size